### PR TITLE
feat(analytics): adding click events

### DIFF
--- a/components/Contact/Contact.tsx
+++ b/components/Contact/Contact.tsx
@@ -55,6 +55,7 @@ export const Contact = ({ contactRef }: ContactProps) => {
               free to email me.
             </Text>
             <Button
+              data-attr="autocapture-button"
               component="a"
               href="mailto:seguardado88@gmail.com"
               size="xl"

--- a/components/Navigation/Navigation.tsx
+++ b/components/Navigation/Navigation.tsx
@@ -11,6 +11,7 @@ import useStyles, {
   SocialContainer,
   MobileLinkContainer,
 } from './Navigation.styles';
+import { usePostHog } from 'posthog-js/react';
 
 interface LinkProps {
   link: string;
@@ -23,6 +24,7 @@ interface NavigationProps {
 }
 
 const Navigation = ({ links }: NavigationProps) => {
+  const posthog = usePostHog();
   const [opened, { toggle }] = useDisclosure(false);
   const [scroll] = useWindowScroll();
   const [active, setActive] = useState<string>('');
@@ -44,6 +46,7 @@ const Navigation = ({ links }: NavigationProps) => {
       className={cx(classes.link, { [classes.linkActive]: active === link.link })}
       onClick={(event: React.MouseEvent<HTMLAnchorElement>) => {
         event.preventDefault();
+        posthog?.capture(`${link.label.split(' ').join('_').toLowerCase()}_clicked`);
         setActive(link.link);
         link.scrollFunction();
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sauls-portfolio",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION


---

<details open="true"><summary>Generated summary (powered by <a href="https://app.graphite.dev">Graphite</a>)</summary>

> ## TL;DR
> This pull request introduces analytics tracking to the navigation links and the contact button in the portfolio website. It also bumps the version of the portfolio from 1.2.0 to 1.3.0.
> 
> ## What changed
> 1. Added `data-attr="autocapture-button"` to the contact button in `Contact.tsx` to enable tracking of button clicks.
> 2. Imported `usePostHog` from `posthog-js/react` in `Navigation.tsx` to enable tracking of navigation link clicks.
> 3. Added a `posthog?.capture` call in the `onClick` handler of each navigation link to send an event to PostHog whenever a link is clicked.
> 4. Bumped the version of the portfolio from 1.2.0 to 1.3.0 in `package.json`.
> 
> ## How to test
> 1. Pull the changes from this PR and run the portfolio locally.
> 2. Click on the contact button and the navigation links.
> 3. Check the PostHog dashboard to see if the events are being sent correctly.
> 
> ## Why make this change
> Adding analytics tracking to the portfolio will help us understand how users are interacting with the website. This will allow us to make data-driven decisions when improving the portfolio in the future.
</details>