### PR TITLE
fix(analytics): removing capture code

### DIFF
--- a/components/Navigation/Navigation.tsx
+++ b/components/Navigation/Navigation.tsx
@@ -11,7 +11,6 @@ import useStyles, {
   SocialContainer,
   MobileLinkContainer,
 } from './Navigation.styles';
-import { usePostHog } from 'posthog-js/react';
 
 interface LinkProps {
   link: string;
@@ -24,7 +23,6 @@ interface NavigationProps {
 }
 
 const Navigation = ({ links }: NavigationProps) => {
-  const posthog = usePostHog();
   const [opened, { toggle }] = useDisclosure(false);
   const [scroll] = useWindowScroll();
   const [active, setActive] = useState<string>('');
@@ -46,7 +44,6 @@ const Navigation = ({ links }: NavigationProps) => {
       className={cx(classes.link, { [classes.linkActive]: active === link.link })}
       onClick={(event: React.MouseEvent<HTMLAnchorElement>) => {
         event.preventDefault();
-        posthog?.capture(`${link.label.split(' ').join('_').toLowerCase()}_clicked`);
         setActive(link.link);
         link.scrollFunction();
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sauls-portfolio",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION


---

<details open="true"><summary>Generated summary (powered by <a href="https://app.graphite.dev">Graphite</a>)</summary>

> ## TL;DR
> This pull request removes the use of `posthog-js/react` from the `Navigation` component and updates the version of the project in `package.json`.
> 
> ## What changed
> - Removed the import and usage of `usePostHog` from `posthog-js/react` in `Navigation.tsx`.
> - Removed the `posthog?.capture` call when a navigation link is clicked.
> - Updated the version of the project in `package.json` from `1.3.0` to `1.3.1`.
> 
> ## How to test
> 1. Pull the changes from this branch into your local environment.
> 2. Run the project and navigate to different sections of the site using the navigation links.
> 3. Ensure that navigation still works as expected and no errors are thrown in the console.
> 
> ## Why make this change
> The `posthog-js/react` library was being used to capture events when navigation links were clicked. However, this functionality is no longer needed, so the library has been removed to reduce the project's dependencies and improve performance. The version of the project has been updated to reflect this change.
</details>